### PR TITLE
ffmpeg: set target android instead linux

### DIFF
--- a/android/do-compile-android-ffmpeg.sh
+++ b/android/do-compile-android-ffmpeg.sh
@@ -295,7 +295,7 @@ FF_CFG_FLAGS="$FF_CFG_FLAGS --cc=clang --host-cflags= --host-ldflags="
 # with ffmpeg Advanced options (experts only):
 FF_CFG_FLAGS="$FF_CFG_FLAGS --cross-prefix=${FF_TOOLCHAIN_PATH}/bin/${FF_CROSS_PREFIX_NAME}-"
 FF_CFG_FLAGS="$FF_CFG_FLAGS --enable-cross-compile"
-FF_CFG_FLAGS="$FF_CFG_FLAGS --target-os=linux"
+FF_CFG_FLAGS="$FF_CFG_FLAGS --target-os=android"
 FF_CFG_FLAGS="$FF_CFG_FLAGS --enable-pic"
 
 if [ "$FF_ARCH" = "x86" ]; then


### PR DESCRIPTION
avoiding .so.version suffix